### PR TITLE
V2.0.0 Updates:

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ const lang = locales('en');
 
 ## Templates
 
-Template files tend to be HTML files but can be any kind of file. The templates are embedded into a template literal inside of the `template.mjs` file.
+Template files tend to be HTML files but can be any kind of file. As a result of the compile process the contents of the template files are embedded into a template literal inside of the `template.mjs` file.
 
-The template file `person.html`:
+For example, if there is a template file called `person.html`:
 
 ```html
 <div class="person">
@@ -161,12 +161,93 @@ The template file `person.html`:
 </div>
 ```
 
-Would create a `templates.mjs` file with:
+Then the entry generated in the `templates.mjs` file would be:
 
 ```JavaScript
   case 'person':
     return `<div class="person"> <div>Name: <span class="name">Frank N Stein</span></div> </div>`;
 ```
+
+### The back-tick: ```
+
+Since all templates become ES6 Template literals you can do some creative things in your tempalte files. Let's say that you want to create a `<table>` with 5 rows. You could do it like this:
+
+```html
+<table>
+  <tr class="row1">
+    <td>1</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>
+  <tr class="row2">
+    <td>1</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>
+  <tr class="row3">
+    <td>3</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>
+  <tr class="row4">
+    <td>4</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>
+  <tr class="row5">
+    <td>5</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>
+</table>
+```
+
+Or you can embed an second ES6 template literal within your template:
+
+```html
+<table>
+  ${[1,2,3,4,5].map( i => `<tr class="row${i}">
+    <td>${i}</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>`).join('')}
+</table>
+```
+
+When you get this string it will execute this template literal expression:
+
+```javascript
+[1,2,3,4,5].map( i => `<tr class="row${i}">
+  <td>${i}</td>
+  <td class="name"></td>
+  <td class="age"></td>
+</tr>`).join('')
+```
+
+This, in turn will return five copies of the internal HTML (The `<tr>` with its three `<td>` tags). THe `join('')` will convert them into a string and this will be inserted just inside the `<table>` tags.
+
+The end result of the two example above are almost identical. Since we removed the duplication of code the second example is more flexible and less prone to errors.
+
+---
+
+#### Escaping the back-tick
+
+If you need to add a back-tick ``` character into your template, outside of your template literals, then you must escape it like with the backslash, like this:
+
+```
+  <p>This is the back-tick: \`</p>
+```
+
+This allows the back-tick to exist as a stand alone character and not as the ending of the generated template literal.
+
+The compiled output would be this:
+
+```
+return `<p>This is the back-tick: \`</p>`;
+```
+
+---
+
 
 ### Using locale strings in templates
 
@@ -208,6 +289,36 @@ templates.str = function(key, data) {
 }
 ```
 
+### Passing data into a template
+
+The signature of the functions `tempates.str` and `tempaltes.dom` is:
+
+```
+function(key, data) {}
+```
+
+So when your code calls either `tempates.str` and `tempaltes.dom` you can pass any object as the second parameter.
+
+> The first parameter is they key used to get the correct template.
+
+If you wanted to create a table with an number or rows defined by a variable you would create your template like this:
+
+Template file `content.html`:
+
+```html
+<table>
+  ${[...Array(data.size).keys()].map( i => `<tr class="row${i}">
+    <td>${i}</td>
+    <td class="name"></td>
+    <td class="age"></td>
+  </tr>`).join('')}
+</table>
+```
+
+If you called `templates.str('content', {size: 10})` then you would get 10 rows created. If you called `templates.str('content', {size: 87})` then you would get 87 rows created.
+
+You can pass in any data and use it any way your imagination can imagine. You just need to follow the rules for [template literals](http://devdocs.io/javascript/template_literals).
+
 ### Adding an `import` in a template
 
 Sometimes you need to be able to access external code within a template.
@@ -239,10 +350,9 @@ The import line of code will be inserted into the top of `templates.mjs`. _You c
 
 | Date | Version | Description |
 | --- | --- | --- |
+| 06/05/2018 | 2.0.0 | **Breaking Changes!!**<br>&#x25cf; Removed the escaping of the back-tick in tempaltes. This was preventing sub-ES6 Template Literals in the templates.<br/>&#x25cf; You now must list the source folders. In most cases you would change from `srcPath: "modules/src"` to `srcPath: "modules/src/*"`<br/>&#x25cf; Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.<br/>&#x25cf; `addKELocale` is now `false` by default<br/>&#x25cf; `alwaysReturnFile` is now `false` by default.<br/>&#x25cf; `defaultLocaleVariable` is now set to `document.documentElement.lang` which is the value set in the `lang` attribute of the `<html>` tag: `<html lang="fr">` would use `fr` as the default value when getting the `lang` object.<br/>&#x25cf; `includePath` is now `false` by default.<br/>&#x25cf; New config options `dstExtCJS`, `dstExtCJS5`, `dstExtIIFE`, `dstExtIIFE5` and `dstExtMJS` allow you to set the output extension for the various output file types |
 | 05/29/2018 | 1.1.0 | &#x25cf; Added code to allow template files to define imports they need.<br/>&#x25cf; Improved Docs. Added Travis and Code Climate. |
 | 05/10/2018 | 1.0.2 | &#x25cf; Corrected REGEX to get correct file names for locale files.<br/>&#x25cf; Improved error output to simplify debugging. |
 | 04/03/2018 | 1.0.1 | &#x25cf; Added pre-commit tests. |
 | 03/29/2018 | 1.0.0 | &#x25cf; Added options for `addKELocale`, `defaultLocaleVariable ` and `sourcemap`.<br/>&#x25cf; Spelling Correction: Renamed option `minTempalteWS` to `minTemplateWS`.<br/>&#x25cf; If there are no compiled files to generate and `alwaysReturnFile` if set to `false` then no temporary folder is created. |
 | 02/26/2018 | 0.0.0 | Initial Release. |
-
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will also need to install the latest `rollup` in your project
 
 ## Usage
 
-Here is a sample `rollup.config.js` file:
+Here are two sample `rollup.config.js` files:
 
 ```JavaScript
 const rollup = require('./node_modules/component-build-tools/rollup.root.config');
@@ -31,9 +31,24 @@ const config = {
 module.exports = rollup.init(config);
 ```
 
+and
+
+```JavaScript
+const {init, BUILD_TYPES} = require('./node_modules/component-build-tools/rollup.root.config');
+
+const config = {
+  buildTypes: [ BUILD_TYPES.MJS, BUILD_TYPES.CJS, BUILD_TYPES.CJS5 ],
+  srcFolders: ['assets/*']
+};
+
+module.exports = init(config);
+```
+
 Then, to run rollup:
 
-    ./node_modules/.bin/rollup -c
+```shell
+./node_modules/.bin/rollup -c
+```
 
 ## Options
 
@@ -56,27 +71,44 @@ When you call `rollup.init` you pass in a set of options. Most are optional. The
 | Option | Type | Default Value | Description |
 | --- | --- | --- | --- |
 | addEOLocale | bool | `true` | Add the EO (Esperanto) locale if it does not exist. |
-| addKELocale | bool | `true` | Add the KE locale if it does not exist. This is a fake locale that returns the KEY as the string to help in debugging. |
-| alwaysReturnFile | bool | `true` | The files `_compiled/locales.msj` and `_compiled/templates.mjs` will always be created if this value is `true`. Otherwise they will not be created. |
+| addKELocale | bool | `false` | Add the KE locale if it does not exist. This is a fake locale that returns the KEY as the string to help in debugging. |
+| alwaysReturnFile | bool | `false` | The files `_compiled/locales.msj` and `_compiled/templates.mjs` will always be created if this value is `true`. Otherwise they will not be created. |
 | buildTypes |array | `[`<br/>&nbsp;&nbsp;`BUILD_TYPES.MJS,`<br/>&nbsp;&nbsp;`BUILD_TYPES.IIFE`<br/>`]` | The list of build styles to create. See Build Styles above. |
 | debug | bool | `false` | `true` to enable debug output. |
 | defaultLocale | string | `'en'` | The locale to use as the default locale when compiling locale files. |
-| defaultLocaleVariable | string | `'window.locale'` | The variable to use as the default locale that is read at runtime that your app defines. |
-| distPath | string | `'dist/js'` | Path into which the distribution files will be placed.|
-| includePath | bool | `true` | Place the dist files inside a folder named after the source folder. |
-| localeFiles | array | `['locales/strings_*.json']` | An array of relative globby paths defining the locale files to load. |
+| defaultLocaleVariable | string | `'document.documentElement.lang'` | The variable to use as the default locale that is read at runtime that your app defines.<br/>`document.documentElement.lang` is the value stored in the `lang` attribute of the `<html>` tag. Changing that value will change what locale strings are used.<br/>`<html lang='en'>` will use the `'en'` locale strings.<br/>`<html lang="fr">` will use the `'fr'` locale strings. |
+| distPath | string/object | `'dist/js'` | Path into which the distribution files will be placed.<br/>If `distPath` is an object then it must include one entry per output type defined in `buildTypes`.<br/>_See [`distPath`](#distPath) below._ |
+| includePath | bool | `false` | If this is set to `false` then the output files are placed directly into the `distPath` folder. If this is set to `true` then the output files are placed in a child folder named after the source folder inside the `distPath` folder. |
+| localeFiles | array | `['locales/strings_*.json']` | An array of relative glob paths defining the locale files to load. |
 | makeMinFiles | bool | `false` | If set to `true` then the output will include creating minimized files. |
 | minTemplateWS | bool | `true` | Minimize the white space within the template files. |
-| separateByLocale | bool | `false` | **Currently not supported** When `true` this will generate one output file per locale supported in the `localesFile` globby list. `false` will only produce one file with all locale data embeded. |
+| separateByLocale | bool | `false` | **Currently not supported** When `true` this will generate one output file per locale supported in the `localesFile` glob list. `false` will only produce one file with all locale data embedded. |
 | sourcemap  | bool | `false` | If `true` then sourcemap files are generated. If `false` then sourcemap files are not generated. |
 | srcFileName | string | `undefined` | If undefined then we use the folder name to specify the source file name. Otherwise the `srcFileName` string is used.<br/>_See [`srcFileName`](#srcFileName) below._ |
-| srcFolders | array | `[]` | Which folders to look into for source files.<br/>**This is required**<br/>_See [`srcFolders`](#srcFolders) below._ |
+| srcFolders | string/array | `[]` | An array of glob folders in which to look into for source files.<br/>**This is required. The user must supply this value.**<br/>_See [`srcFolders`](#srcFolders) below._ |
 | tagMissingStrings | bool | `true` | When `true` Mark missing locale strings so they are easily seen. |
-| templateFiles | array | `['*.html']` | A globby array of files to include as templates. |
+| templateFiles | array | `['*.html']` | A glob array of files to include as templates. |
 | tempLocalesName | string | `'locales.mjs'` | The filename used for the compiled `locales` file. |
 | tempPath | string | `'./_compiled/'` | The path into which all compiled files are place. |
 | tempTemplateName | string | `'templates.mjs'` | The filename used for the compiled `templates` file. |
 | useStrict | bool | `false` | If `true` then add `"use strict"` at the top of the rolled up output files. |
+
+#### distPath
+
+If `distPath` is a string then the same `distPath` is used in the output for any build type.
+
+You can also define `distPath` as an object to change the output path for each build type.
+
+If you  set `buildType` to `[BUILD_TYPES.MJS, BUILD_TYPES.CJS]` then your `distPath` object needs to include two properties, one per build type:
+
+```JavaScript
+distPath: {
+  MJS: './path/for/mjs/built/files',
+  CJS: './cjs/file/path'
+}
+```
+
+> If you include extra properties they will be ignored. But you must include one property per build type. If you don't then an exception will be thrown and the build will fail.
 
 #### srcFileName
 
@@ -84,51 +116,62 @@ If `srcFileName` is left as `undefined` then the name of the source files will b
 
 For example, the file structure below shows a folder named `test1` and within it is a file named `test1.mjs`. The build process of the build tools will take `test1.mjs` as the root file to use in the rollup config file.
 
-```
-+- components
-   +- test1
-      +- test1.msj
-      +- style.html
-      +- content.html
+```shell
+└─ components
+   └─ test1
+      ├─ test1.msj
+      ├─ style.html
+      └─ content.html
 ```
 
 And the default output file will be placed in:
 
-```
-+- dist
-   +- js
-      +- test1
-         +- test1.mjs
+```shell
+└─ dist
+   └─ js
+      └─ test1.mjs
 ```
 
 The output file `./dist/js/test1/test1.mjs` will combine the two template files `style.html` and `content.html` as well as the source file `test1.js` as one set of code.
 
 If `srcFileName` were set to `index.mjs` then the build tools would use `index.msj` as the root file to use in the rollup config file.
 
-```
-+- components
-   +- test1
-      +- index.msj
-      +- style.html
-      +- content.html
+```shell
+└─ components
+   └─ test1
+      ├─ index.msj
+      ├─ style.html
+      └─ content.html
 ```
 
 would still produce the same output structure of:
 
+```shell
+└─ dist
+   └─ js
+      └─ test1.mjs
 ```
-+- dist
-   +- js
-      +- test1
-         +- test1.mjs
+
+If the value for `includePath` had been set to true then the output structure would be:
+
+```shell
+└─ dist
+   └─ js
+      └─ test1
+         └─ test1.mjs
 ```
 
 #### srcFolders
 
 `srcFolder` is the only option that must be supplied. This specifies the folder or folders that are to be processed by the build tools.
 
-If you have all of your components in the folder `./comps` then you would call `rollup.init({srcFolders:['./comps']})`.
+If you have all of your components stored in child fodlers of the folder `./comps` then you would call `rollup.init({srcFolders:['./comps/*']})`.
 
 Every folder directly under `./comps` would get processed. Any subfolder that was found to match the requirements of a component will be handed off to rollup for further processing.
+
+You can specify each folder independently within the array, And each entry in the array can either be a real path to a specific folder or a glob path to a set of folders.
+
+> `rollup.init({srcFolders:['./comps/component1']})` will only look at the path `./comps/component1` while `rollup.init({srcFolders:['./comps/*']})` will look at all direct child folders under `./comps`.
 
 ## Locale files
 
@@ -164,8 +207,8 @@ For example, if there is a template file called `person.html`:
 Then the entry generated in the `templates.mjs` file would be:
 
 ```JavaScript
-  case 'person':
-    return `<div class="person"> <div>Name: <span class="name">Frank N Stein</span></div> </div>`;
+case 'person':
+  return `<div class="person"> <div>Name: <span class="name">Frank N Stein</span></div> </div>`;
 ```
 
 ### The back-tick: ```
@@ -216,7 +259,7 @@ Or you can embed an second ES6 template literal within your template:
 
 When you get this string it will execute this template literal expression:
 
-```javascript
+```JavaScript
 [1,2,3,4,5].map( i => `<tr class="row${i}">
   <td>${i}</td>
   <td class="name"></td>
@@ -234,15 +277,15 @@ The end result of the two example above are almost identical. Since we removed t
 
 If you need to add a back-tick ``` character into your template, outside of your template literals, then you must escape it like with the backslash, like this:
 
-```
-  <p>This is the back-tick: \`</p>
+```html
+<p>This is the back-tick: \`</p>
 ```
 
 This allows the back-tick to exist as a stand alone character and not as the ending of the generated template literal.
 
 The compiled output would be this:
 
-```
+```JavaScript
 return `<p>This is the back-tick: \`</p>`;
 ```
 
@@ -293,7 +336,7 @@ templates.str = function(key, data) {
 
 The signature of the functions `templates.str` and `templates.dom` is:
 
-```
+```JavaScript
 function(key, data) {}
 ```
 
@@ -350,7 +393,7 @@ The import line of code will be inserted into the top of `templates.mjs`. _You c
 
 | Date | Version | Description |
 | --- | --- | --- |
-| 06/05/2018 | 2.0.0 | **Breaking Changes!!**<br>&#x25cf; Removed the escaping of the back-tick in templates. This was preventing sub-ES6 Template Literals in the templates.<br/>&#x25cf; You now must list the source folders. In most cases you would change from `srcPath: "modules/src"` to `srcPath: "modules/src/*"`<br/>&#x25cf; Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.<br/>&#x25cf; `addKELocale` is now `false` by default<br/>&#x25cf; `alwaysReturnFile` is now `false` by default.<br/>&#x25cf; `defaultLocaleVariable` is now set to `document.documentElement.lang` which is the value set in the `lang` attribute of the `<html>` tag: `<html lang="fr">` would use `fr` as the default value when getting the `lang` object.<br/>&#x25cf; `includePath` is now `false` by default.<br/>&#x25cf; New config options `dstExtCJS`, `dstExtCJS5`, `dstExtIIFE`, `dstExtIIFE5` and `dstExtMJS` allow you to set the output extension for the various output file types |
+| 06/07/2018 | 2.0.0 | **Breaking Changes!!**<br>&#x25cf; Removed the escaping of the back-tick in templates. This was preventing sub-ES6 Template Literals in the templates.<br/>&#x25cf; You now must list the source folders. In most cases you would change from `srcPath: "modules/src"` to `srcPath: "modules/src/*"`<br/>&#x25cf; Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.<br/>&#x25cf; `addKELocale` is now `false` by default<br/>&#x25cf; `alwaysReturnFile` is now `false` by default.<br/>&#x25cf; `defaultLocaleVariable` is now set to `document.documentElement.lang` which is the value set in the `lang` attribute of the `<html>` tag: `<html lang="fr">` would use `fr` as the default value when getting the `lang` object.<br/>&#x25cf; `includePath` is now `false` by default.<br/>&#x25cf; New config options `dstExtCJS`, `dstExtCJS5`, `dstExtIIFE`, `dstExtIIFE5` and `dstExtMJS` allow you to set the output extension for the various output file types.<br/>&#x25cf; Added ability for `distPath` to be an object and not just a string.<br/>&#x25cf; Added and cleaned up Docs<br/>&#x25cf; Added more testing for the new code. |
 | 05/29/2018 | 1.1.0 | &#x25cf; Added code to allow template files to define imports they need.<br/>&#x25cf; Improved Docs. Added Travis and Code Climate. |
 | 05/10/2018 | 1.0.2 | &#x25cf; Corrected REGEX to get correct file names for locale files.<br/>&#x25cf; Improved error output to simplify debugging. |
 | 04/03/2018 | 1.0.1 | &#x25cf; Added pre-commit tests. |

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Then the entry generated in the `templates.mjs` file would be:
 
 ### The back-tick: ```
 
-Since all templates become ES6 Template literals you can do some creative things in your tempalte files. Let's say that you want to create a `<table>` with 5 rows. You could do it like this:
+Since all templates become ES6 Template literals you can do some creative things in your template files. Let's say that you want to create a `<table>` with 5 rows. You could do it like this:
 
 ```html
 <table>
@@ -291,17 +291,17 @@ templates.str = function(key, data) {
 
 ### Passing data into a template
 
-The signature of the functions `tempates.str` and `tempaltes.dom` is:
+The signature of the functions `templates.str` and `templates.dom` is:
 
 ```
 function(key, data) {}
 ```
 
-So when your code calls either `tempates.str` and `tempaltes.dom` you can pass any object as the second parameter.
+So when your code calls either `templates.str` and `templates.dom` you can pass any object as the second parameter.
 
 > The first parameter is they key used to get the correct template.
 
-If you wanted to create a table with an number or rows defined by a variable you would create your template like this:
+If you wanted to create a table with a number of rows defined by a variable you would create your template like this:
 
 Template file `content.html`:
 
@@ -350,7 +350,7 @@ The import line of code will be inserted into the top of `templates.mjs`. _You c
 
 | Date | Version | Description |
 | --- | --- | --- |
-| 06/05/2018 | 2.0.0 | **Breaking Changes!!**<br>&#x25cf; Removed the escaping of the back-tick in tempaltes. This was preventing sub-ES6 Template Literals in the templates.<br/>&#x25cf; You now must list the source folders. In most cases you would change from `srcPath: "modules/src"` to `srcPath: "modules/src/*"`<br/>&#x25cf; Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.<br/>&#x25cf; `addKELocale` is now `false` by default<br/>&#x25cf; `alwaysReturnFile` is now `false` by default.<br/>&#x25cf; `defaultLocaleVariable` is now set to `document.documentElement.lang` which is the value set in the `lang` attribute of the `<html>` tag: `<html lang="fr">` would use `fr` as the default value when getting the `lang` object.<br/>&#x25cf; `includePath` is now `false` by default.<br/>&#x25cf; New config options `dstExtCJS`, `dstExtCJS5`, `dstExtIIFE`, `dstExtIIFE5` and `dstExtMJS` allow you to set the output extension for the various output file types |
+| 06/05/2018 | 2.0.0 | **Breaking Changes!!**<br>&#x25cf; Removed the escaping of the back-tick in templates. This was preventing sub-ES6 Template Literals in the templates.<br/>&#x25cf; You now must list the source folders. In most cases you would change from `srcPath: "modules/src"` to `srcPath: "modules/src/*"`<br/>&#x25cf; Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.<br/>&#x25cf; `addKELocale` is now `false` by default<br/>&#x25cf; `alwaysReturnFile` is now `false` by default.<br/>&#x25cf; `defaultLocaleVariable` is now set to `document.documentElement.lang` which is the value set in the `lang` attribute of the `<html>` tag: `<html lang="fr">` would use `fr` as the default value when getting the `lang` object.<br/>&#x25cf; `includePath` is now `false` by default.<br/>&#x25cf; New config options `dstExtCJS`, `dstExtCJS5`, `dstExtIIFE`, `dstExtIIFE5` and `dstExtMJS` allow you to set the output extension for the various output file types |
 | 05/29/2018 | 1.1.0 | &#x25cf; Added code to allow template files to define imports they need.<br/>&#x25cf; Improved Docs. Added Travis and Code Climate. |
 | 05/10/2018 | 1.0.2 | &#x25cf; Corrected REGEX to get correct file names for locale files.<br/>&#x25cf; Improved error output to simplify debugging. |
 | 04/03/2018 | 1.0.1 | &#x25cf; Added pre-commit tests. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "component-build-tools",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -812,9 +812,9 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has-ansi": {
@@ -1169,42 +1169,37 @@
       }
     },
     "mocha": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
-      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
+        "commander": "2.15.1",
         "debug": "3.1.0",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1242,9 +1237,9 @@
       }
     },
     "nyc": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
-      "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+      "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -1262,10 +1257,10 @@
         "istanbul-lib-instrument": "1.10.1",
         "istanbul-lib-report": "1.1.3",
         "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.3.0",
+        "istanbul-reports": "1.4.0",
         "md5-hex": "1.3.0",
         "merge-source-map": "1.1.0",
-        "micromatch": "2.3.11",
+        "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
         "resolve-from": "2.0.0",
         "rimraf": "2.6.2",
@@ -1315,12 +1310,9 @@
           "dev": true
         },
         "arr-diff": {
-          "version": "2.0.0",
+          "version": "4.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
@@ -1333,7 +1325,7 @@
           "dev": true
         },
         "array-unique": {
-          "version": "0.2.1",
+          "version": "0.3.2",
           "bundled": true,
           "dev": true
         },
@@ -1353,7 +1345,7 @@
           "dev": true
         },
         "atob": {
-          "version": "2.0.3",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -1377,7 +1369,7 @@
             "babel-types": "6.26.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
@@ -1395,7 +1387,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1408,7 +1400,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "lodash": "4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "babel-traverse": {
@@ -1423,8 +1415,8 @@
             "babylon": "6.18.0",
             "debug": "2.6.9",
             "globals": "9.18.0",
-            "invariant": "2.2.3",
-            "lodash": "4.17.5"
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "babel-types": {
@@ -1434,7 +1426,7 @@
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "to-fast-properties": "1.0.3"
           }
         },
@@ -1470,8 +1462,39 @@
                 "is-descriptor": "1.0.2"
               }
             },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -1487,13 +1510,30 @@
           }
         },
         "braces": {
-          "version": "1.8.5",
+          "version": "2.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "builtin-modules": {
@@ -1581,59 +1621,8 @@
                 "is-descriptor": "0.1.6"
               }
             },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "5.1.0",
               "bundled": true,
               "dev": true
             }
@@ -1698,7 +1687,7 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.5.3",
+          "version": "2.5.6",
           "bundled": true,
           "dev": true
         },
@@ -1707,7 +1696,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "which": "1.3.0"
           }
         },
@@ -1751,8 +1740,39 @@
             "isobject": "3.0.1"
           },
           "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -1803,7 +1823,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "shebang-command": "1.2.0",
                 "which": "1.3.0"
               }
@@ -1811,19 +1831,35 @@
           }
         },
         "expand-brackets": {
-          "version": "0.1.5",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "2.2.3"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "extend-shallow": {
@@ -1846,28 +1882,88 @@
           }
         },
         "extglob": {
-          "version": "0.3.2",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "fill-range": {
-          "version": "2.2.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -1892,14 +1988,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
         },
         "foreground-child": {
           "version": "1.5.6",
@@ -1949,23 +2037,6 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
           }
         },
         "globals": {
@@ -2091,7 +2162,7 @@
           "dev": true
         },
         "invariant": {
-          "version": "2.2.3",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2104,18 +2175,11 @@
           "dev": true
         },
         "is-accessor-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -2137,57 +2201,32 @@
           }
         },
         "is-data-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
-          "version": "1.0.2",
+          "version": "0.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
-              "version": "6.0.2",
+              "version": "5.1.0",
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "2.0.0"
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -2204,16 +2243,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
         "is-number": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2250,16 +2281,6 @@
             }
           }
         },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "is-stream": {
           "version": "1.1.0",
           "bundled": true,
@@ -2286,12 +2307,9 @@
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
+          "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
@@ -2364,7 +2382,7 @@
           }
         },
         "istanbul-reports": {
-          "version": "1.3.0",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2432,7 +2450,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
+          "version": "4.17.10",
           "bundled": true,
           "dev": true
         },
@@ -2450,7 +2468,7 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2508,23 +2526,30 @@
           }
         },
         "micromatch": {
-          "version": "2.3.11",
+          "version": "3.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "mimic-fn": {
@@ -2624,14 +2649,6 @@
             "validate-npm-package-license": "3.0.3"
           }
         },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
@@ -2667,39 +2684,6 @@
               "requires": {
                 "is-descriptor": "0.1.6"
               }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "5.1.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
             }
           }
         },
@@ -2716,15 +2700,6 @@
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
           }
         },
         "object.pick": {
@@ -2799,17 +2774,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
         },
         "parse-json": {
           "version": "2.2.0",
@@ -2899,52 +2863,10 @@
           "bundled": true,
           "dev": true
         },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
         "pseudomap": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -2981,14 +2903,6 @@
           "bundled": true,
           "dev": true
         },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
@@ -2997,11 +2911,6 @@
             "extend-shallow": "3.0.2",
             "safe-regex": "1.1.0"
           }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
@@ -3155,57 +3064,6 @@
               "requires": {
                 "is-extendable": "0.1.1"
               }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -3227,8 +3085,39 @@
                 "is-descriptor": "1.0.2"
               }
             },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -3252,7 +3141,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.0.3",
+            "atob": "2.1.1",
             "decode-uri-component": "0.2.0",
             "resolve-url": "0.2.1",
             "source-map-url": "0.4.0",
@@ -3329,57 +3218,6 @@
               "requires": {
                 "is-descriptor": "0.1.6"
               }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -3439,7 +3277,7 @@
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
-            "micromatch": "3.1.9",
+            "micromatch": "3.1.10",
             "object-assign": "4.1.1",
             "read-pkg-up": "1.0.1",
             "require-main-filename": "1.0.1"
@@ -3456,17 +3294,15 @@
               "dev": true
             },
             "braces": {
-              "version": "2.3.1",
+              "version": "2.3.2",
               "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "1.1.0",
                 "array-unique": "0.3.2",
-                "define-property": "1.0.0",
                 "extend-shallow": "2.0.1",
                 "fill-range": "4.0.0",
                 "isobject": "3.0.1",
-                "kind-of": "6.0.2",
                 "repeat-element": "1.1.2",
                 "snapdragon": "0.8.2",
                 "snapdragon-node": "2.1.1",
@@ -3474,14 +3310,6 @@
                 "to-regex": "3.0.2"
               },
               "dependencies": {
-                "define-property": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "1.0.2"
-                  }
-                },
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
@@ -3520,6 +3348,42 @@
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
                   }
                 },
                 "is-descriptor": {
@@ -3594,39 +3458,29 @@
               }
             },
             "is-accessor-descriptor": {
-              "version": "0.1.6",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
-              "version": "0.1.4",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-number": {
@@ -3658,13 +3512,13 @@
               "dev": true
             },
             "micromatch": {
-              "version": "3.1.9",
+              "version": "3.1.10",
               "bundled": true,
               "dev": true,
               "requires": {
                 "arr-diff": "4.0.0",
                 "array-unique": "0.3.2",
-                "braces": "2.3.1",
+                "braces": "2.3.2",
                 "define-property": "2.0.2",
                 "extend-shallow": "3.0.2",
                 "extglob": "2.0.4",
@@ -3943,7 +3797,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "4.1.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -3968,7 +3822,7 @@
               "dev": true
             },
             "cliui": {
-              "version": "4.0.0",
+              "version": "4.1.0",
               "bundled": true,
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,13 @@
 {
   "name": "component-build-tools",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A set of build tools to simplify the creation of components",
   "main": "rollup.root.config.js",
-  "scripts": {
-    "debug": "mocha --inspect-brk test/**/*.test.js",
-    "lint": "eslint \"*.js\" \"test/*.js\"",
-    "test": "npm run lint && bin/unit-tests"
-  },
+  "author": "Michael G Collins <intervalia@gmail.com> (http://www.intervalia.com/)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/intervalia/component-build-tools.git"
   },
-  "author": "Michael G Collins <intervalia@gmail.com> (http://www.intervalia.com/)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/intervalia/component-build-tools/issues"
@@ -31,9 +26,14 @@
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-html": "^4.0.3",
-    "mocha": "^5.0.4",
-    "nyc": "^11.6.0",
+    "mocha": "^5.2.0",
+    "nyc": "^11.9.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1"
+  },
+  "scripts": {
+    "debug": "mocha --inspect-brk test/**/*.test.js",
+    "lint": "eslint \"*.js\" \"test/*.js\"",
+    "test": "npm run lint && bin/unit-tests"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,24 +3,22 @@
   "version": "2.0.0",
   "description": "A set of build tools to simplify the creation of components",
   "main": "rollup.root.config.js",
-  "author": "Michael G Collins <intervalia@gmail.com> (http://www.intervalia.com/)",
+  "author": "Michael G Collins <intervalia@gmail.com> http://www.intervalia.com/",
+  "contributors": [
+    "Michael G Collins <intervalia@gmail.com> http://www.intervalia.com/"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/intervalia/component-build-tools.git"
   },
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/intervalia/component-build-tools/issues"
   },
-  "homepage": "https://github.com/intervalia/component-build-tools#readme",
   "dependencies": {
     "glob": "^7.1.2",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-uglify-es": "0.0.1"
   },
-  "pre-commit": [
-    "test"
-  ],
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
@@ -31,6 +29,11 @@
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1"
   },
+  "homepage": "https://github.com/intervalia/component-build-tools#readme",
+  "license": "MIT",
+  "pre-commit": [
+    "test"
+  ],
   "scripts": {
     "debug": "mocha --inspect-brk test/**/*.test.js",
     "lint": "eslint \"*.js\" \"test/*.js\"",

--- a/readFile.js
+++ b/readFile.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 function readFile(filePath) {
-  return fs.readFileSync(filePath, {encoding: 'utf-8'}).trim().replace(/`/g, '\\`');
+  return fs.readFileSync(filePath, {encoding: 'utf-8'}).trim();
 }
 
 module.exports = readFile;

--- a/test/rollup.root.config.test.js
+++ b/test/rollup.root.config.test.js
@@ -38,6 +38,108 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(rollupConfig.BUILD_TYPES).to.be.an('object');
   });
 
+  it('should handle invalid `sourcemap`', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        sourcemap: 'badthings'
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The value for `config.sourcemap` must be [true | false | "inline"].');
+      done();
+    }
+  });
+
+  it('should handle invalid `srcFolders`', () => {
+    let resp = rollupConfig.init({
+      srcFolders: 'test/testFolders/rollupFolders/onlyOneMJS/one/one.mjs'
+    });
+
+    expect(resp).to.eql([]);
+  });
+
+  it('should handle invalid `distPath` 1', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        distPath: 123
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The value for `config.distPath` must be a `string` or an `object`.');
+      done();
+    }
+  });
+
+  it('should handle invalid `distPath` 2', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        distPath: {
+          dog: ''
+        }
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The value for `config.distPath.MJS` is missing.');
+      done();
+    }
+  });
+
+  it('should handle invalid `distPath` 3', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        distPath: {
+          MJS: 'apath'
+        }
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The value for `config.distPath.CJS` is missing.');
+      done();
+    }
+  });
+
+  it('should handle invalid `buildType` 1', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        buildTypes: null
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The value for `config.buildTypes` is invalid.');
+      done();
+    }
+  });
+
+  it('should handle invalid `buildType` 2', (done) => {
+    try {
+      let resp = rollupConfig.init({
+        buildTypes: ['dogs']
+      });
+      done('Exception was not thrown.');
+    }
+
+    catch (ex) {
+      expect(ex instanceof TypeError).to.equal(true);
+      expect(ex.message).to.equal('The `config.buildTypes` value of `dogs` is invalid.');
+      done();
+    }
+  });
+
   it('should process nothing with no `srcFolders` set', () => {
     let resp = rollupConfig.init();
 
@@ -52,6 +154,14 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(resp).to.eql([]);
   });
 
+  it('should process a folder with srcFolders as a string', () => {
+    let resp = rollupConfig.init({
+      srcFolders: 'test/testFolders/rollupFolders/noCompile'
+    });
+
+    expect(resp).to.eql([]);
+  });
+
   it('should process a folder with one MSJ to compile', () => {
     let resp = rollupConfig.init({
       distPath: 'test/testFolders/rollupFolders/dist',
@@ -61,11 +171,51 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(resp.length).to.equal(2);
     expect(resp[0].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
     expect(resp[0].output.format).to.equal('es');
-    expect(resp[0].output.sourcemap).to.equal(undefined); // eslint-disable-line no-undefined
+    expect(resp[0].output.sourcemap).to.equal(false);
     expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.mjs');
     expect(resp[1].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
     expect(resp[1].output.format).to.equal('cjs');
-    expect(resp[1].output.sourcemap).to.equal(undefined); // eslint-disable-line no-undefined
+    expect(resp[1].output.sourcemap).to.equal(false);
+    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.cjs.js');
+    expect(writtenFiles.length).to.equal(0);
+  });
+
+  it('should handle valid `distPath` object', () => {
+    let resp = rollupConfig.init({
+      dstExtCJS: '.js',
+      dstExtMJS: '.js',
+      distPath: {
+        MJS: 'test/testFolders/rollupFolders/dist/mjs',
+        CJS: 'test/testFolders/rollupFolders/dist/cjs'
+      },
+      srcFolders: ['test/testFolders/rollupFolders/onlyOneMJS/one']
+    });
+
+    expect(resp.length).to.equal(2);
+    expect(resp[0].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
+    expect(resp[0].output.format).to.equal('es');
+    expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/mjs/one.js');
+    expect(resp[1].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
+    expect(resp[1].output.format).to.equal('cjs');
+    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/cjs/one.js');
+    expect(writtenFiles.length).to.equal(0);
+  });
+
+  it('should process a folder with one MSJ to compile with inline source maps', () => {
+    let resp = rollupConfig.init({
+      distPath: 'test/testFolders/rollupFolders/dist',
+      sourcemap: 'inline',
+      srcFolders: ['test/testFolders/rollupFolders/onlyOneMJS/one']
+    });
+
+    expect(resp.length).to.equal(2);
+    expect(resp[0].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
+    expect(resp[0].output.format).to.equal('es');
+    expect(resp[0].output.sourcemap).to.equal('inline');
+    expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.mjs');
+    expect(resp[1].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
+    expect(resp[1].output.format).to.equal('cjs');
+    expect(resp[1].output.sourcemap).to.equal('inline');
     expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.cjs.js');
     expect(writtenFiles.length).to.equal(0);
   });
@@ -105,17 +255,18 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(locales('ke').LABEL_NAME).to.equal('LABEL_NAME');
   });
 
+  //eslint-disable-next-line max-statements
   it('should process a folder with one MSJ with templates and locales to compile', () => {
     let resp = rollupConfig.init({
       addKELocale: true,
-      buildTypes: [rollupConfig.BUILD_TYPES.IIFE5, rollupConfig.BUILD_TYPES.CJS, rollupConfig.BUILD_TYPES.CJS5],
+      buildTypes: [rollupConfig.BUILD_TYPES.IIFE5, rollupConfig.BUILD_TYPES.CJS, rollupConfig.BUILD_TYPES.CJS5, rollupConfig.BUILD_TYPES.IIFE],
       distPath: 'test/testFolders/rollupFolders/dist',
       makeMinFiles: true,
       srcFolders: ['test/testFolders/rollupFolders/MJSWithLocalesAndTemplates/*'],
       sourcemap: true
     });
 
-    expect(resp.length).to.equal(6);
+    expect(resp.length).to.equal(8);
     expect(resp[0].output.format).to.equal('iife');
     expect(resp[0].plugins.length).to.equal(1, 'iife only buble');
     expect(resp[0].plugins[0].name).to.equal('buble');
@@ -137,6 +288,12 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(resp[5].plugins.length).to.equal(2);
     expect(resp[5].plugins[0].name).to.equal('buble');
     expect(resp[5].plugins[1].name).to.equal('uglify');
+
+    expect(resp[6].output.format).to.equal('iife');
+    expect(resp[6].plugins.length).to.equal(0, 'iife');
+    expect(resp[7].output.format).to.equal('iife');
+    expect(resp[7].plugins.length).to.equal(1, 'iife and uglify');
+    expect(resp[7].plugins[0].name).to.equal('uglify');
 
     expect(writtenFiles.length).to.equal(2);
     expect(writtenFiles[0].file.split('test/testFolders')[1]).to.equal('/rollupFolders/MJSWithLocalesAndTemplates/one/_compiled/locales.mjs');

--- a/test/rollup.root.config.test.js
+++ b/test/rollup.root.config.test.js
@@ -54,28 +54,28 @@ describe('Testing file `rollup.root.config.js`', () => {
 
   it('should process a folder with one MSJ to compile', () => {
     let resp = rollupConfig.init({
-      alwaysReturnFile: false,
       distPath: 'test/testFolders/rollupFolders/dist',
-      srcFolders: ['test/testFolders/rollupFolders/onlyOneMJS']
+      srcFolders: ['test/testFolders/rollupFolders/onlyOneMJS/one']
     });
 
     expect(resp.length).to.equal(2);
     expect(resp[0].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
     expect(resp[0].output.format).to.equal('es');
     expect(resp[0].output.sourcemap).to.equal(undefined); // eslint-disable-line no-undefined
-    expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one/one.mjs');
+    expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.mjs');
     expect(resp[1].input.split('test/testFolders')[1]).to.equal('/rollupFolders/onlyOneMJS/one/one.mjs');
-    expect(resp[1].output.format).to.equal('iife');
+    expect(resp[1].output.format).to.equal('cjs');
     expect(resp[1].output.sourcemap).to.equal(undefined); // eslint-disable-line no-undefined
-    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one/one.iife.js');
+    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one.cjs.js');
     expect(writtenFiles.length).to.equal(0);
   });
 
   it('should process a folder with one MSJ with locales to compile', () => {
     let resp = rollupConfig.init({
-      alwaysReturnFile: false,
+      addKELocale: true,
+      includePath: true,
       distPath: 'test/testFolders/rollupFolders/dist',
-      srcFolders: ['test/testFolders/rollupFolders/MJSWithLocales'],
+      srcFolders: ['test/testFolders/rollupFolders/MJSWithLocales/*'],
       sourcemap: true
     });
 
@@ -85,9 +85,9 @@ describe('Testing file `rollup.root.config.js`', () => {
     expect(resp[0].output.sourcemap).to.equal(true);
     expect(resp[0].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one/one.mjs');
     expect(resp[1].input.split('test/testFolders')[1]).to.equal('/rollupFolders/MJSWithLocales/one/one.mjs');
-    expect(resp[1].output.format).to.equal('iife');
+    expect(resp[1].output.format).to.equal('cjs');
     expect(resp[1].output.sourcemap).to.equal(true);
-    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one/one.iife.js');
+    expect(resp[1].output.file.split('test/testFolders')[1]).to.equal('/rollupFolders/dist/one/one.cjs.js');
     expect(writtenFiles.length).to.equal(1);
     expect(writtenFiles[0].file.split('test/testFolders')[1]).to.equal('/rollupFolders/MJSWithLocales/one/_compiled/locales.mjs');
 
@@ -107,11 +107,11 @@ describe('Testing file `rollup.root.config.js`', () => {
 
   it('should process a folder with one MSJ with templates and locales to compile', () => {
     let resp = rollupConfig.init({
+      addKELocale: true,
       buildTypes: [rollupConfig.BUILD_TYPES.IIFE5, rollupConfig.BUILD_TYPES.CJS, rollupConfig.BUILD_TYPES.CJS5],
-      alwaysReturnFile: false,
       distPath: 'test/testFolders/rollupFolders/dist',
       makeMinFiles: true,
-      srcFolders: ['test/testFolders/rollupFolders/MJSWithLocalesAndTemplates'],
+      srcFolders: ['test/testFolders/rollupFolders/MJSWithLocalesAndTemplates/*'],
       sourcemap: true
     });
 


### PR DESCRIPTION
**This release includes breaking changes.**

● Removed the escaping of the back-tick in templates. This was preventing sub-ES6 Template Literals in the templates.
● You now must list the source folders. In most cases you would change from srcPath: "modules/src" to srcPath: "modules/src/*"
● Changed default build types from MJS and IIFE to MJS and CJS since these can both be loaded in a similar manner.
● addKELocale is now false by default
● alwaysReturnFile is now false by default.
● defaultLocaleVariable is now set to document.documentElement.lang which is the value set in the lang attribute of the <html> tag: <html lang="fr"> would use fr as the default value when getting the lang object.
● includePath is now false by default.
● New config options dstExtCJS, dstExtCJS5, dstExtIIFE, dstExtIIFE5 and dstExtMJS allow you to set the output extension for the various output file types.
● Added ability for distPath to be an object and not just a string.
● Added and cleaned up Docs
● Added more testing for the new code.